### PR TITLE
release otelzap/v0.2.0

### DIFF
--- a/otelzap/CHANGELOG
+++ b/otelzap/CHANGELOG
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [v0.2.0]
+
 ### Changed
 
 - opentelemetry-go updated to 1.18.0

--- a/otelzap/version.go
+++ b/otelzap/version.go
@@ -18,5 +18,5 @@ package otelzap
 
 // Version is the current release version of OpenTelemetry Zap in use.
 func Version() string {
-	return "0.1.1"
+	return "0.2.0"
 }


### PR DESCRIPTION
## [v0.2.0]

### Changed

- opentelemetry-go updated to 1.18.0
- opentelemetry-logs-go updated to 0.3.0
- zap updated to 1.26.0
