### PR TITLE
fix(otelzap): preserve logs level on method With

### DIFF
--- a/otelzap/core.go
+++ b/otelzap/core.go
@@ -54,6 +54,7 @@ func (c *otlpCore) With(f []zapcore.Field) zapcore.Core {
 	return &otlpCore{
 		logger: c.logger,
 		fields: fields,
+		level:  c.level,
 	}
 }
 


### PR DESCRIPTION
Fix for the behaviour when log level reset after applying method `With` and not propagated to new logger