### PR TITLE
chore(dependabot): Adding Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/otelslog"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore(deps): update"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gomod"
+    directory: "/otelzap"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore(deps): update"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gomod"
+    directory: "/otelzerolog"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore(deps): update"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
With this, we can keep the repository with updated dependencies, and whenever there is an update, a PR will be sent.